### PR TITLE
feat: add Braille Translator CLI application

### DIFF
--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,1 +1,56 @@
-# TypeScript Instructions
+# Braille Translator
+
+A TypeScript-based CLI application for translating between English and Braille.
+
+## Installation
+
+```
+npm install
+```
+
+## Build
+
+```
+npm run build
+```
+
+## Usage
+
+### Direct Translation
+
+Translate English to Braille or Braille to English directly:
+
+```
+node build/translator.js <text>
+```
+
+Examples:
+```
+node build/translator.js Hello world
+node build/translator.js 42
+node build/translator.js .O.OOOOO.O..O.O...
+```
+
+### Interactive Mode
+
+Run the application in interactive mode:
+
+```
+node build/translator.js
+```
+
+This opens a menu-driven interface for continuous translations until you choose to exit.
+
+## Features
+
+- Bidirectional translation between English and Braille
+- Support for uppercase letters, numbers, and spaces
+- Interactive CLI with user-friendly prompts
+
+## Testing
+
+Run the test suite:
+
+```
+npm test
+```

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,13 +1,14 @@
 {
   "name": "typescript",
-  "version": "1.0.0",
-  "description": "",
+  "version": "1.1.0",
+  "description": "A TypeScript-based CLI application for translating between English and Braille.",
   "main": "translator.ts",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "build": "rm -rf build && tsc"
   },
   "keywords": [],
-  "author": "",
+  "author": "Marcin Koziel <marcinzkoziel@gmail.com> (https://github.com/marcin-koziel)",
   "license": "ISC",
   "devDependencies": {
     "@types/jest": "^29.5.12",

--- a/typescript/src/constants/brailleMap.ts
+++ b/typescript/src/constants/brailleMap.ts
@@ -1,0 +1,30 @@
+import type { BrailleMap } from '../types';
+
+export const brailleMap: BrailleMap = {
+  brailleToEnglishAlphabets: {
+      "O.....": "a", "O.O...": "b", "OO....": "c", "OO.O..": "d", "O..O..": "e",
+      "OOO...": "f", "OOOO..": "g", "O.OO..": "h", ".OO...": "i", ".OOO..": "j",
+      "O...O.": "k", "O.O.O.": "l", "OO..O.": "m", "OO.OO.": "n", "O..OO.": "o",
+      "OOO.O.": "p", "OOOOO.": "q", "O.OOO.": "r", ".OO.O.": "s", ".OOOO.": "t",
+      "O...OO": "u", "O.O.OO": "v", ".OOO.O": "w", "OO..OO": "x", "OO.OOO": "y",
+      "O..OOO": "z", "......": " ", ".....O": "capital", ".O.OOO": "number"
+  },
+
+  brailleToEnglishDigits: {
+      "O.....": "1", "O.O...": "2", "OO....": "3", "OO.O..": "4", "O..O..": "5",
+      "OOO...": "6", "OOOO..": "7", "O.OO..": "8", ".OO...": "9", ".OOO..": "0"
+  },
+
+  englishAlphabetsToBraille: {} as Record<string, string>,
+  englishDigitsToBraille: {} as Record<string, string>
+};
+
+// Initialize englishAlphabetsToBraille
+brailleMap.englishAlphabetsToBraille = Object.fromEntries(
+  Object.entries(brailleMap.brailleToEnglishAlphabets).map(([k, v]) => [v, k])
+);
+
+// Initialize englishDigitsToBraille
+brailleMap.englishDigitsToBraille = Object.fromEntries(
+  Object.entries(brailleMap.brailleToEnglishDigits).map(([k, v]) => [v, k])
+);

--- a/typescript/src/constants/index.ts
+++ b/typescript/src/constants/index.ts
@@ -1,0 +1,3 @@
+export * from './brailleMap';
+export * from './strings';
+

--- a/typescript/src/constants/strings.ts
+++ b/typescript/src/constants/strings.ts
@@ -1,0 +1,25 @@
+export const Strings = {
+  MAIN_MENU: {
+    TRANSLATE: 'Translate text',
+    SETTINGS: 'Settings',
+    EXIT: 'Exit',
+  },
+  SETTINGS_MENU: {
+    CLEAR_CACHE: 'Clear cache',
+    BACK: 'Back to main menu',
+  },
+  ACTIONS: {
+    TRANSLATE: 'translate',
+    SETTINGS: 'settings',
+    EXIT: 'exit',
+    CLEAR_CACHE: 'clearCache',
+    BACK: 'back',
+  },
+  MESSAGES: {
+    EXITING: '👋 Exiting...',
+    INVALID_ACTION: 'Invalid action',
+    TRANSLATED_TEXT: 'Translated text: ',
+    CACHE_CLEARED: 'Cache cleared successfully.',
+    CACHE_CLEAR_CANCELLED: 'Cache clear action cancelled.',
+  },
+};

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1,0 +1,158 @@
+import { Strings, brailleMap } from './constants';
+import MenuPromptService from './services/menuPromptService';
+
+class Translator {
+    private readonly menuPromptService: MenuPromptService;
+
+    constructor() {
+        this.menuPromptService = new MenuPromptService();
+    }
+
+    /**
+     * Main run method for the Translator CLI
+     * Handles interactive mode or direct translation based on input
+     */
+    public async run(words: string[]): Promise<void> {
+        if (words.length > 0) {
+            await this.translateText(words);
+        } else {
+            await this.runInteractiveMode();
+        }
+    }
+
+    /**
+     * Runs the interactive mode with menu prompts
+     */
+    private async runInteractiveMode(): Promise<void> {
+        let isRunning = true;
+        while (isRunning) {
+            const action = await this.menuPromptService.promptMainMenu();
+            isRunning = await this.handleMainMenuAction(action);
+        }
+        console.log('👋 Exiting...');
+    }
+
+    /**
+     * Handles the main menu action
+     * @param action - The selected action from the main menu
+     * @returns boolean indicating whether to continue running
+     */
+    private async handleMainMenuAction(action: string): Promise<boolean> {
+        switch (action) {
+            case Strings.ACTIONS.TRANSLATE:
+                await this.handleTranslateAction();
+                console.log('\n');
+                return true;
+            case Strings.ACTIONS.EXIT:
+                return false;
+            default:
+                console.log(Strings.MESSAGES.INVALID_ACTION);
+                return true;
+        }
+    }
+
+    /**
+     * Translates the given text and outputs the result
+     */
+    private async translateText(words: string[]): Promise<void> {
+        const text = words.join(' ');
+        if (this.isBraille(text)) {
+            const translatedText = this.translateBrailleToEnglish(text);
+            console.log(translatedText);
+        } else {
+            const translatedText = this.translateEnglishToBraille(text);
+            console.log(translatedText);
+        }
+    }
+
+    /**
+     * Handles the translate action
+     * Prompts for text and translates it
+     */
+    private async handleTranslateAction(): Promise<void> {
+        const text = await this.menuPromptService.promptForText();
+        if (this.isBraille(text)) {
+            const translatedText = this.translateBrailleToEnglish(text);
+            console.log(translatedText);
+        } else {
+            const translatedText = this.translateEnglishToBraille(text);
+            console.log(translatedText);
+        }
+    }
+
+    // Function to determine if input is Braille or English
+    private isBraille(input: string): boolean {
+        return /^[O.]+$/.test(input.replace(/\s/g, ''));
+    }
+
+    // Function to convert Braille to English
+    private translateBrailleToEnglish(input: string): string {
+        const brailleSymbols = input.match(/.{6}/g);
+        if (!brailleSymbols) {
+            return '';
+        }
+        let translation = '';
+        let isCapital = false;
+        let isNumber = false;
+
+        brailleSymbols.forEach(symbol => {
+            if (symbol === ".....O") {
+                isCapital = true;
+            } else if (symbol === ".O.OOO") {
+                isNumber = true;
+            } else if (symbol in brailleMap.brailleToEnglishAlphabets) {
+                if (isNumber) {
+                    translation += brailleMap.brailleToEnglishDigits[symbol] || '';
+                } else {
+                    let letter = brailleMap.brailleToEnglishAlphabets[symbol];
+                    if (isCapital && letter !== ' ') {
+                        letter = letter.toUpperCase();
+                        isCapital = false;
+                    }
+                    translation += letter;
+                }
+            } else if (symbol === "......") {
+                translation += ' ';
+                isNumber = false;
+            }
+        });
+        return translation;
+    }
+
+    // Function to convert English to Braille
+    private translateEnglishToBraille(input: string): string {
+        let translation = '';
+        let isNumber = false;
+        let words = input.split(' ');
+
+        for (let i = 0; i < words.length; i++) {
+            let word = words[i];
+            for (let char of word) {
+                if (/[A-Z]/.test(char)) {
+                    translation += brailleMap.englishAlphabetsToBraille['capital'];
+                    translation += brailleMap.englishAlphabetsToBraille[char.toLowerCase()];
+                } else if (/[a-z]/.test(char)) {
+                    translation += brailleMap.englishAlphabetsToBraille[char];
+                } else if (/\d/.test(char)) {
+                    if (!isNumber) {
+                        translation += brailleMap.englishAlphabetsToBraille['number'];
+                        isNumber = true;
+                    }
+                    translation += brailleMap.englishDigitsToBraille[char];
+                } else {
+                    if (isNumber && /\D/.test(char)) {
+                        isNumber = false;
+                    }
+                    translation += brailleMap.englishAlphabetsToBraille[char.toLowerCase()] || '';
+                }
+            }
+            // Add six periods (Braille space) between words, except for the last word
+            if (i < words.length - 1) {
+                translation += '......';
+            }
+        }
+        return translation;
+    }
+}
+
+export default Translator;

--- a/typescript/src/services/menuPromptService.ts
+++ b/typescript/src/services/menuPromptService.ts
@@ -1,0 +1,28 @@
+import { Strings } from '../constants/strings';
+import PromptService from './promptService';
+
+class MenuPromptService {
+  private promptService: PromptService;
+
+  constructor() {
+    this.promptService = new PromptService();
+  }
+
+  async promptMainMenu(): Promise<string> {
+    const action = await this.promptService.select(
+      'Translator CLI',
+      [
+        { name: '🌐 Translate', value: Strings.ACTIONS.TRANSLATE },
+        { name: '🚪 Exit', value: Strings.ACTIONS.EXIT }
+      ]
+    );
+    return action;
+  }
+
+  async promptForText(): Promise<string> {
+    const text = await this.promptService.input('Enter the text to translate:', (input: string) => input.trim() !== '' || 'Text cannot be empty');
+    return text;
+  }
+}
+
+export default MenuPromptService;

--- a/typescript/src/services/promptService.ts
+++ b/typescript/src/services/promptService.ts
@@ -1,0 +1,127 @@
+import readline from 'readline';
+import { Choice } from '../types';
+
+class PromptService {
+  constructor() {
+  }
+
+  async select(message: string, choices: Choice[]): Promise<string> {
+    return new Promise((resolve) => {
+      let selectedIndex = 0;
+      let firstRender = true;
+
+      const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+      });
+
+      readline.emitKeypressEvents(process.stdin);
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(true);
+      }
+
+      const render = () => {
+        if (!firstRender) {
+          // Move cursor up by the number of choices plus the message line
+          process.stdout.write(`\x1b[${choices.length + 1}A`);
+        }
+        
+        // Clear the lines
+        process.stdout.write('\x1b[0J');
+        
+        console.log(message);
+        choices.forEach((choice, index) => {
+          if (index === selectedIndex) {
+            console.log(`> ${choice.name}`);
+          } else {
+            console.log(`  ${choice.name}`);
+          }
+        });
+
+        // Hide the cursor
+        process.stdout.write('\x1b[?25l');
+
+        firstRender = false;
+      };
+
+      render();
+
+      process.stdin.on('keypress', (_, key) => {
+        if (key.name === 'up') {
+          selectedIndex = (selectedIndex - 1 + choices.length) % choices.length;
+        } else if (key.name === 'down') {
+          selectedIndex = (selectedIndex + 1) % choices.length;
+        } else if (key.name === 'return') {
+          // Clear the menu
+          process.stdout.write(`\x1b[${choices.length + 2}A`);
+          for (let i = 0; i < choices.length + 1; i++) {
+            process.stdout.write('\x1b[K\n');
+          }
+          process.stdout.write(`\x1b[${choices.length + 1}A`);
+
+          // Display the selected option
+          console.log(`${message}: ${choices[selectedIndex].name}`);
+
+          // Show the cursor again before resolving
+          process.stdout.write('\x1b[?25h');
+
+          rl.close();
+          process.stdin.removeAllListeners('keypress');
+          if (process.stdin.isTTY) {
+            process.stdin.setRawMode(false);
+          }
+          resolve(choices[selectedIndex].value);
+          return;
+        }
+        render();
+      });
+
+      // Ensure the cursor is shown if the process is interrupted
+      process.on('SIGINT', () => {
+        process.stdout.write('\x1b[?25h');
+        process.exit();
+      });
+    });
+  }
+
+  async input(message: string, validate?: (input: string) => boolean | string): Promise<string> {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    });
+
+    const promptUser = (): Promise<string> => {
+      return new Promise((resolve) => {
+        rl.question(message + ' ', (answer) => {
+          if (validate) {
+            const validationResult = validate(answer);
+            if (typeof validationResult === 'string') {
+              console.log(validationResult);
+              resolve(promptUser());
+            } else if (!validationResult) {
+              console.log('Invalid input. Please try again.');
+              resolve(promptUser());
+            } else {
+              rl.close();
+              resolve(answer);
+            }
+          } else {
+            rl.close();
+            resolve(answer);
+          }
+        });
+      });
+    };
+
+    return promptUser();
+  }
+
+  async confirm(message: string, defaultValue: boolean): Promise<boolean> {
+    const answer = await this.input(`${message} (y/n) [${defaultValue ? 'Y/n' : 'y/N'}]: `);
+    if (answer.toLowerCase() === 'y') return true;
+    if (answer.toLowerCase() === 'n') return false;
+    return defaultValue;
+  }
+}
+
+export default PromptService;

--- a/typescript/src/types/index.ts
+++ b/typescript/src/types/index.ts
@@ -1,0 +1,14 @@
+export type Choice = {
+  name: string;
+  value: string;
+}
+
+export type BrailleToEnglish = Record<string, string>;
+export type EnglishToBraille = Record<string, string>;
+
+export type BrailleMap = {
+  brailleToEnglishAlphabets: BrailleToEnglish;
+  brailleToEnglishDigits: BrailleToEnglish;
+  englishAlphabetsToBraille: EnglishToBraille;
+  englishDigitsToBraille: EnglishToBraille;
+};

--- a/typescript/translator.ts
+++ b/typescript/translator.ts
@@ -1,0 +1,14 @@
+import Translator from './src/index';
+
+try {
+    const translator = new Translator();
+    const args = process.argv.slice(2);
+
+    if (args.length > 0) {
+        translator.run(args);
+    } else {
+        translator.run([]);
+    }
+} catch (error) {
+    console.error(error);
+}

--- a/typescript/tsconfig.json
+++ b/typescript/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "CommonJS",
+    "outDir": "./build",
+    "rootDir": ".",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "isolatedModules": true,
+    "baseUrl": ".",
+  },
+  "include": ["src/**/*.ts", "translator.ts"],
+  "exclude": ["node_modules", "src/tests/**/*.ts", "build"]
+}


### PR DESCRIPTION
- Initialize TypeScript-based Braille Translator CLI
- Add bidirectional translation between English and Braille
- Implement interactive mode with menu-driven interface
- Include installation, build, and usage instructions in README
- Provide braille character mappings and main translation logic
- Support Jest for testing